### PR TITLE
Added fix to make pythonRunner compatible with other distros

### DIFF
--- a/src/pythonRunner/pythonRunner.go
+++ b/src/pythonRunner/pythonRunner.go
@@ -9,7 +9,7 @@ import (
 
 // ExecPythonModel function
 func ExecPythonModel(path string, modelFile string, jsonData string) error {
-	cmd := exec.Command("python", path, modelFile, "-j", jsonData)
+	cmd := exec.Command("python3", path, modelFile, "-j", jsonData)
 	// fmt.Printf("\nExecuted command: %s\n\n", cmd.String())
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
Before it called "python", which isn't compatible with some systems. Now it calls "python3" when running python code which makes it work with other systems